### PR TITLE
Tracks interesting goroutines by ID instead of stacktrace

### DIFF
--- a/leaktest_test.go
+++ b/leaktest_test.go
@@ -2,6 +2,7 @@ package leaktest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -105,9 +106,9 @@ func TestChangingStackTrace(t *testing.T) {
 
 func TestInterestingGoroutine(t *testing.T) {
 	s := "goroutine 123 [running]:\nmain.main()"
-	gr, ok := interestingGoroutine(s)
-	if !ok {
-		t.Error("should be ok")
+	gr, err := interestingGoroutine(s)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
 	}
 	if gr.id != 123 {
 		t.Errorf("goroutine id = %d; want %d", gr.id, 123)
@@ -116,16 +117,41 @@ func TestInterestingGoroutine(t *testing.T) {
 		t.Errorf("goroutine stack = %q; want %q", gr.stack, s)
 	}
 
-	stacks := []string{
-		"goroutine 123 [running]:",
-		"goroutine 123 [running]:\ntesting.RunTests",
-		"goroutine 856105:\nmain.main()",
-		"goroutine NaN [running]:\nmain.main()",
+	stacks := []struct {
+		stack string
+		err   error
+	}{
+		{
+			stack: "goroutine 123 [running]:",
+			err:   errors.New(`error parsing stack: "goroutine 123 [running]:"`),
+		},
+		{
+			stack: "goroutine 123 [running]:\ntesting.RunTests",
+			err:   nil,
+		},
+		{
+			stack: "goroutine 123 [running]:\nfoo\nbar\nruntime.goexit\nbaz",
+			err:   nil,
+		},
+		{
+			stack: "goroutine 123:\nmain.main()",
+			err:   errors.New(`error parsing stack header: "goroutine 123:"`),
+		},
+		{
+			stack: "goroutine NaN [running]:\nmain.main()",
+			err:   errors.New(`error parsing goroutine id: strconv.ParseUint: parsing "NaN": invalid syntax`),
+		},
 	}
-	for _, s := range stacks {
-		_, ok := interestingGoroutine(s)
-		if ok {
-			t.Errorf("should not be ok: %q", s)
+	for i, s := range stacks {
+		gr, err := interestingGoroutine(s.stack)
+		if s.err == nil && err != nil {
+			t.Errorf("%d: error = %v; want nil", i, err)
+		} else if s.err != nil && (err == nil || err.Error() != s.err.Error()) {
+			t.Errorf("%d: error = %v; want %s", i, err, s.err)
 		}
+		if gr != nil {
+			t.Errorf("%d: gr = %v; want nil", i, gr)
+		}
+
 	}
 }


### PR DESCRIPTION
Previously the leak detection compared the goroutine stacks from
the starting of a function with their stacks at the end to find
new goroutines. But, when there are preexisting goroutines whose
stacks change during the function, they are incorrectly detected
as a leaked goroutine. This update compare goroutine IDs instead.