### PR TITLE
Fix timeouts on slow tests

### DIFF
--- a/leaktest.go
+++ b/leaktest.go
@@ -103,10 +103,13 @@ func Check(t ErrorReporter) func() {
 
 // CheckTimeout is the same as Check, but with a configurable timeout
 func CheckTimeout(t ErrorReporter, dur time.Duration) func() {
-	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	ctx, cancel := context.WithCancel(context.Background())
 	fn := CheckContext(ctx, t)
 	return func() {
+		timer := time.AfterFunc(dur, cancel)
 		fn()
+		// Remember to clean up the timer and context
+		timer.Stop()
 		cancel()
 	}
 }

--- a/leaktest_test.go
+++ b/leaktest_test.go
@@ -76,6 +76,16 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+// TestSlowTest verifies that the timeout works on slow tests: it should
+// be based on time after the test finishes rather than time after the test's
+// start.
+func TestSlowTest(t *testing.T) {
+	defer CheckTimeout(t, 1000 * time.Millisecond)()
+
+	go time.Sleep(1500 * time.Millisecond)
+	time.Sleep(750 * time.Millisecond)
+}
+
 func TestEmptyLeak(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
Start the timeout only after the deferred function is executed.

Uses @seglberg's implementation, with some additional cleanup.

Fixes #19 